### PR TITLE
Build mods i686

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,6 @@ To build a non-x86 architectural version of an external package simply build it 
   ../crypto-repo/build --pkgname . --all --cpu xxx --install ../hercpkgs
 
 
-Hercules currently understands the following non-x86 cpu architectures: arm, mips, ppc, sparc, xscale, s390x and unknown.
+Hercules currently understands the following non-x86 cpu architectures: aarch64, arm, i686, mips, ppc, s390x, sparc, xscale, and unknown.
 
 -------------------------------------------------------------------------------

--- a/build
+++ b/build
@@ -999,21 +999,11 @@ validate_args()
     errmsg "ERROR: Invalid machine cpu \"$cpu\""
   fi
 
-  if [[ "$cpu" == "x86"  ]] || \
-     [[ "$cpu" == "i686" ]]; then
-    cpu=""
-  fi
-
-  #----------------------------------------------------------------------------
-  #  Validate arg sanity
-
-  #  Check for conflicting options, etc...
-
-  # We do not do a 64-bit build for i686
-  trace "Debug: checking for incorrect i686 bitness"
+  # We do not try a 64-bit build for i686
+  trace "Debug: checking for 64-bit i686"
   if [[ "$cpu" == "i686" ]] && \
      [[ "$arch" == "64" ]]; then
-    errmsg "ERROR: i686 builds are 32-bit only."
+    errmsg "ERROR: i686 builds are intended to be 32-bit only."
   fi
 
   # We cannot build a 32-bit aarch64, nor a 64-bit arm
@@ -1027,6 +1017,16 @@ validate_args()
      [[ "$arch" == "32" ]]; then
     errmsg "ERROR: aarch64 builds are 64-bit only."
   fi
+
+  if [[ "$cpu" == "x86"  ]] || \
+     [[ "$cpu" == "i686" ]]; then
+    cpu=""
+  fi
+
+  #----------------------------------------------------------------------------
+  #  Validate arg sanity
+
+  #  Check for conflicting options, etc...
 
   if [[ -n $install ]] && [[ -n $uninstall ]]; then
     errmsg "ERROR: Cannot specify both install and uninstall."

--- a/build
+++ b/build
@@ -47,8 +47,9 @@ help()
   errmsg ""
   errmsg "        cpu        The machine (CPU) architecture of the target system"
   errmsg "                   if other than x86.  Recognized machine architectures"
-  errmsg "                   are: aarch64, arm, mips, ppc, sparc, xscale, s390x, x86"
-  errmsg "                   and unknown.  The default if not specified is x86."
+  errmsg "                   are: aarch64, arm, i686, mips, ppc, s390x, sparc,"
+  errmsg "                   x86, xscale, and unknown."
+  errmsg "                   The default if not specified is x86."
   errmsg ""
   errmsg "        arch       The build architecture. Use '32' to build an x86"
   errmsg "                   32-bit version of the package. Use '64' to build"
@@ -987,17 +988,19 @@ validate_args()
 
   if [[ "$cpu" != "aarch64" ]]  && \
      [[ "$cpu" != "arm"     ]]  && \
+     [[ "$cpu" != "i686"    ]]  && \
      [[ "$cpu" != "mips"    ]]  && \
      [[ "$cpu" != "ppc"     ]]  && \
-     [[ "$cpu" != "sparc"   ]]  && \
-     [[ "$cpu" != "xscale"  ]]  && \
-     [[ "$cpu" != "x86"     ]]  && \
      [[ "$cpu" != "s390x"   ]]  && \
+     [[ "$cpu" != "sparc"   ]]  && \
+     [[ "$cpu" != "x86"     ]]  && \
+     [[ "$cpu" != "xscale"  ]]  && \
      [[ "$cpu" != "unknown" ]]; then
     errmsg "ERROR: Invalid machine cpu \"$cpu\""
   fi
 
-  if [[ "$cpu" == "x86" ]]; then
+  if [[ "$cpu" == "x86"  ]] || \
+     [[ "$cpu" == "i686" ]]; then
     cpu=""
   fi
 
@@ -1006,8 +1009,14 @@ validate_args()
 
   #  Check for conflicting options, etc...
 
-# WRL 2020-07-07
-# WRL We cannot build a 32-bit aarch64, nor a 64-bit arm
+  # We do not do a 64-bit build for i686
+  trace "Debug: checking for incorrect i686 bitness"
+  if [[ "$cpu" == "i686" ]] && \
+     [[ "$arch" == "64" ]]; then
+    errmsg "ERROR: i686 builds are 32-bit only."
+  fi
+
+  # We cannot build a 32-bit aarch64, nor a 64-bit arm
   trace "Debug: checking for incorrect arm/aarch64 bitness"
   if [[ "$cpu" == "arm" ]] && \
      [[ "$arch" == "64" ]]; then


### PR DESCRIPTION
Add a new build type 'i686', and don't try to do 64-bit builds on 32-bit i686 machines.

Similar to what we already do for ARM 32-bit vs. AARCH64 64-bit, these changes split out building on Linux 32-bit i686 systems.

The full package as a unit affects the four extpkgs, crypt, decNumber, SoftFloat, and telnet.  Plus the driver in gists.
