### PR TITLE
security : Do not rely on setting automatic variables to 0 on functio…

### DIFF
--- a/source/sha1.c
+++ b/source/sha1.c
@@ -116,7 +116,9 @@ SHA1Transform(u_int32_t state[5], const unsigned char buffer[SHA1_BLOCK_LENGTH])
     explicit_bzero(&c,sizeof(c));
     explicit_bzero(&d,sizeof(d));
     explicit_bzero(&e,sizeof(e));
-    return;
+#ifdef SHA1HANDSOFF
+    explicit_bzero(workspace,sizeof(workspace));
+#endif
 }
 
 

--- a/source/sha1.c
+++ b/source/sha1.c
@@ -111,7 +111,12 @@ SHA1Transform(u_int32_t state[5], const unsigned char buffer[SHA1_BLOCK_LENGTH])
     state[3] += d;
     state[4] += e;
     /* Wipe variables */
-    a = b = c = d = e = 0;
+    explicit_bzero(&a,sizeof(a));
+    explicit_bzero(&b,sizeof(b));
+    explicit_bzero(&c,sizeof(c));
+    explicit_bzero(&d,sizeof(d));
+    explicit_bzero(&e,sizeof(e));
+    return;
 }
 
 

--- a/source/sha2.c
+++ b/source/sha2.c
@@ -357,15 +357,15 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        explicit_bzero(a,sizeof(a));
-        explicit_bzero(b,sizeof(b));
-        explicit_bzero(c,sizeof(c));
-        explicit_bzero(d,sizeof(d));
-        explicit_bzero(e,sizeof(e));
-        explicit_bzero(f,sizeof(f));
-        explicit_bzero(g,sizeof(g));
-        explicit_bzero(h,sizeof(h));
-        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(&a,sizeof(a));
+        explicit_bzero(&b,sizeof(b));
+        explicit_bzero(&c,sizeof(c));
+        explicit_bzero(&d,sizeof(d));
+        explicit_bzero(&e,sizeof(e));
+        explicit_bzero(&f,sizeof(f));
+        explicit_bzero(&g,sizeof(g));
+        explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&T1,sizeof(T1));
         explicit_bzero(W256,sizeof(W256));
 }
 
@@ -442,16 +442,16 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        explicit_bzero(a,sizeof(a));
-        explicit_bzero(b,sizeof(b));
-        explicit_bzero(c,sizeof(c));
-        explicit_bzero(d,sizeof(d));
-        explicit_bzero(e,sizeof(e));
-        explicit_bzero(f,sizeof(f));
-        explicit_bzero(g,sizeof(g));
-        explicit_bzero(h,sizeof(h));
-        explicit_bzero(T1,sizeof(T1));
-        explicit_bzero(T2,sizeof(T2));
+        explicit_bzero(&a,sizeof(a));
+        explicit_bzero(&b,sizeof(b));
+        explicit_bzero(&c,sizeof(c));
+        explicit_bzero(&d,sizeof(d));
+        explicit_bzero(&e,sizeof(e));
+        explicit_bzero(&f,sizeof(f));
+        explicit_bzero(&g,sizeof(g));
+        explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&T1,sizeof(T1));
+        explicit_bzero(&T2,sizeof(T2));
         explicit_bzero(W256,sizeof(W256));
 }
 
@@ -654,15 +654,15 @@ SHA512Transform(u_int64_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        explicit_bzero(a,sizeof(a));
-        explicit_bzero(b,sizeof(b));
-        explicit_bzero(c,sizeof(c));
-        explicit_bzero(d,sizeof(d));
-        explicit_bzero(e,sizeof(e));
-        explicit_bzero(f,sizeof(f));
-        explicit_bzero(g,sizeof(g));
-        explicit_bzero(h,sizeof(h));
-        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(&a,sizeof(a));
+        explicit_bzero(&b,sizeof(b));
+        explicit_bzero(&c,sizeof(c));
+        explicit_bzero(&d,sizeof(d));
+        explicit_bzero(&e,sizeof(e));
+        explicit_bzero(&f,sizeof(f));
+        explicit_bzero(&g,sizeof(g));
+        explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&T1,sizeof(T1));
         explicit_bzero(W512,sizeof(W512));
 }
 
@@ -741,16 +741,16 @@ SHA512Transform(u_int64_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        explicit_bzero(a,sizeof(a));
-        explicit_bzero(b,sizeof(b));
-        explicit_bzero(c,sizeof(c));
-        explicit_bzero(d,sizeof(d));
-        explicit_bzero(e,sizeof(e));
-        explicit_bzero(f,sizeof(f));
-        explicit_bzero(g,sizeof(g));
-        explicit_bzero(h,sizeof(h));
-        explicit_bzero(T1,sizeof(T1));
-        explicit_bzero(T2,sizeof(T2));
+        explicit_bzero(&a,sizeof(a));
+        explicit_bzero(&b,sizeof(b));
+        explicit_bzero(&c,sizeof(c));
+        explicit_bzero(&d,sizeof(d));
+        explicit_bzero(&e,sizeof(e));
+        explicit_bzero(&f,sizeof(f));
+        explicit_bzero(&g,sizeof(g));
+        explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&T1,sizeof(T1));
+        explicit_bzero(&T2,sizeof(T2));
         explicit_bzero(W512,sizeof(W512));
 }
 

--- a/source/sha2.c
+++ b/source/sha2.c
@@ -357,7 +357,16 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        a = b = c = d = e = f = g = h = T1 = 0;
+        explicit_bzero(a,sizeof(a));
+        explicit_bzero(b,sizeof(b));
+        explicit_bzero(c,sizeof(c));
+        explicit_bzero(d,sizeof(d));
+        explicit_bzero(e,sizeof(e));
+        explicit_bzero(f,sizeof(f));
+        explicit_bzero(g,sizeof(g));
+        explicit_bzero(h,sizeof(h));
+        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(W256,sizeof(W256));
 }
 
 #else /* SHA2_UNROLL_TRANSFORM */
@@ -433,7 +442,17 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        a = b = c = d = e = f = g = h = T1 = T2 = 0;
+        explicit_bzero(a,sizeof(a));
+        explicit_bzero(b,sizeof(b));
+        explicit_bzero(c,sizeof(c));
+        explicit_bzero(d,sizeof(d));
+        explicit_bzero(e,sizeof(e));
+        explicit_bzero(f,sizeof(f));
+        explicit_bzero(g,sizeof(g));
+        explicit_bzero(h,sizeof(h));
+        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(T2,sizeof(T2));
+        explicit_bzero(W256,sizeof(W256));
 }
 
 #endif /* SHA2_UNROLL_TRANSFORM */
@@ -635,7 +654,16 @@ SHA512Transform(u_int64_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        a = b = c = d = e = f = g = h = T1 = 0;
+        explicit_bzero(a,sizeof(a));
+        explicit_bzero(b,sizeof(b));
+        explicit_bzero(c,sizeof(c));
+        explicit_bzero(d,sizeof(d));
+        explicit_bzero(e,sizeof(e));
+        explicit_bzero(f,sizeof(f));
+        explicit_bzero(g,sizeof(g));
+        explicit_bzero(h,sizeof(h));
+        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(W512,sizeof(W512));
 }
 
 #else /* SHA2_UNROLL_TRANSFORM */
@@ -713,7 +741,17 @@ SHA512Transform(u_int64_t *state, const u_int8_t *data)
         state[7] += h;
 
         /* Clean up */
-        a = b = c = d = e = f = g = h = T1 = T2 = 0;
+        explicit_bzero(a,sizeof(a));
+        explicit_bzero(b,sizeof(b));
+        explicit_bzero(c,sizeof(c));
+        explicit_bzero(d,sizeof(d));
+        explicit_bzero(e,sizeof(e));
+        explicit_bzero(f,sizeof(f));
+        explicit_bzero(g,sizeof(g));
+        explicit_bzero(h,sizeof(h));
+        explicit_bzero(T1,sizeof(T1));
+        explicit_bzero(T2,sizeof(T2));
+        explicit_bzero(W512,sizeof(W512));
 }
 
 #endif /* SHA2_UNROLL_TRANSFORM */

--- a/source/sha2.c
+++ b/source/sha2.c
@@ -365,6 +365,8 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         explicit_bzero(&f,sizeof(f));
         explicit_bzero(&g,sizeof(g));
         explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&s0,sizeof(s0));
+        explicit_bzero(&s1,sizeof(s1));
         explicit_bzero(&T1,sizeof(T1));
         explicit_bzero(W256,sizeof(W256));
 }
@@ -450,6 +452,8 @@ SHA256Transform(u_int32_t *state, const u_int8_t *data)
         explicit_bzero(&f,sizeof(f));
         explicit_bzero(&g,sizeof(g));
         explicit_bzero(&h,sizeof(h));
+        explicit_bzero(&s0,sizeof(s0));
+        explicit_bzero(&s1,sizeof(s1));
         explicit_bzero(&T1,sizeof(T1));
         explicit_bzero(&T2,sizeof(T2));
         explicit_bzero(W256,sizeof(W256));
@@ -559,7 +563,7 @@ SHA256Final(u_int8_t digest[], SHA2_CTX *context)
         memcpy(digest, context->state.st32, SHA256_DIGEST_LENGTH);
         /* Clean up state data: */
         explicit_bzero(context, sizeof(*context));
-        usedspace = 0;
+        explicit_bzero(&usedspace,sizeof(usedspace));
 }
 
 
@@ -748,6 +752,8 @@ SHA512Transform(u_int64_t *state, const u_int8_t *data)
         explicit_bzero(&e,sizeof(e));
         explicit_bzero(&f,sizeof(f));
         explicit_bzero(&g,sizeof(g));
+        explicit_bzero(&s0,sizeof(s0));
+        explicit_bzero(&s1,sizeof(s1));
         explicit_bzero(&h,sizeof(h));
         explicit_bzero(&T1,sizeof(T1));
         explicit_bzero(&T2,sizeof(T2));


### PR DESCRIPTION
…n exit. Use explicit_bzero() instead

Because of compiler optimization, setting automatic variables before they go out of scope are likely to be optimized out. The values may still be in the stack.