### PR TITLE
Find bash on NetBSD

### DIFF
--- a/build
+++ b/build
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
   #  If this bash script works then it was written by Fish.
   #  If it doesn't then I don't know who the heck wrote it.
 
-  _versnum="2.4"
-  _versdate="December 8, 2020"
+  _versnum="2.5"
+  _versdate="January 3, 2021"
 
 #------------------------------------------------------------------------------
 #                                   BUILD


### PR DESCRIPTION
Use 'env' to find Bash on NetBSD.

NetBSD doesn't keep Bash in /bin, so we use the 'env' program to find it.

This is part of ongoing work to get the build working on NetBSD.
