### PR TITLE
Allow crypto to be used with `add_subdirectory()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/platform.h.in )
     message( FATAL_ERROR "Unable to find platform.h.in!" )
 else()
     configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/platform.h.in
-                    ${CMAKE_BINARY_DIR}/platform.h )
+                    ${CMAKE_CURRENT_BINARY_DIR}/platform.h )
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,11 @@ set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE
 #   Load some handy CMake modules
 #------------------------------------------------------------------------------
 
-if( NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/modules" )
-    message( FATAL_ERROR "CMake modules directory not found! ${CMAKE_SOURCE_DIR}/cmake/modules" )
+if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" )
+	message( FATAL_ERROR "CMake modules directory not found! ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" )
 else()
 
-    set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules" )
+	set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" )
 
     include( Vdump )
     include( Trace )
@@ -76,7 +76,7 @@ check_header( stdint.h )        # defines HAVE_STDINT_H
 #   Always generate the platform.h header
 #------------------------------------------------------------------------------
 
-if( NOT EXISTS ${CMAKE_SOURCE_DIR}/platform.h.in )
+if( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/platform.h.in )
     message( FATAL_ERROR "Unable to find platform.h.in!" )
 else()
     configure_file( ${CMAKE_SOURCE_DIR}/platform.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ configure_file( "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
 
 #  Now simply define an uninstall target that will run the above script.
 
-add_custom_target( uninstall
+add_custom_target( ${EXTPKG_NAME}_uninstall
                    COMMAND ${CMAKE_COMMAND} -P
                    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ check_header( stdint.h )        # defines HAVE_STDINT_H
 if( NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/platform.h.in )
     message( FATAL_ERROR "Unable to find platform.h.in!" )
 else()
-    configure_file( ${CMAKE_SOURCE_DIR}/platform.h.in
+    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/platform.h.in
                     ${CMAKE_BINARY_DIR}/platform.h )
 endif()
 

--- a/cmake/modules/ParseBinaryDir.cmake
+++ b/cmake/modules/ParseBinaryDir.cmake
@@ -133,7 +133,7 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
         message( WARNING "Invalid package architecture! ${BITNESS}" )
         message( WARNING "Defaulting to 64-bit" )
         set( BITNESS "64" )
-        set( BASENAME "crypto" )
+        set( BASENAME ${EXTPKG_NAME} )
     endif()
 
     #--------------------------------------------------------------------------

--- a/cmake/modules/ParseBinaryDir.cmake
+++ b/cmake/modules/ParseBinaryDir.cmake
@@ -82,8 +82,7 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
     if( ${_n} LESS 1 )
         message( WARNING "Invalid Release/Debug build type! ${CONFIG}" )
         message( WARNING "Defaulting to Release_64" )
-        set ( CONFIG "Release" )
-        set ( LENGTH "_64" )
+        set( CONFIG "Release" )
     endif()
 
     #--------------------------------------------------------------------------
@@ -95,7 +94,9 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
     Capitalize_Word( ${CONFIG} CONFIG )
 
     if(( NOT CONFIG STREQUAL "Debug" ) AND (NOT CONFIG STREQUAL "Release" ))
-        message( FATAL_ERROR "Invalid Release/Debug build type! ${CONFIG}" )
+        message( WARNING "Invalid Release/Debug build type! ${CONFIG}" )
+        message( WARNING "Defaulting to Release_64" )
+        set( CONFIG "Release" )
     endif()
 
     #--------------------------------------------------------------------------
@@ -119,7 +120,7 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
 
     string( LENGTH ${_xxxxx} _n )
     if( ${_n} LESS 3 )
-        message( FATAL_ERROR "Invalid base package name! ${_xxxxx}" )
+        message( WARNING "Invalid base package name! ${_xxxxx}" )
     endif()
 
     math( EXPR _n "${_n} - 2" )     # (want the last two characters)
@@ -129,7 +130,10 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
 
     if( NOT BITNESS STREQUAL "32" AND
         NOT BITNESS STREQUAL "64" )
-        message( FATAL_ERROR "Invalid package architecture! ${BITNESS}" )
+        message( WARNING "Invalid package architecture! ${BITNESS}" )
+        message( WARNING "Defaulting to 64-bit" )
+        set( BITNESS "64" )
+        set( BASENAME "crypto" )
     endif()
 
     #--------------------------------------------------------------------------

--- a/cmake/modules/ParseBinaryDir.cmake
+++ b/cmake/modules/ParseBinaryDir.cmake
@@ -80,7 +80,10 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
 
     string( LENGTH ${CONFIG} _n )
     if( ${_n} LESS 1 )
-        message( FATAL_ERROR "Invalid Release/Debug build type! ${CONFIG}" )
+        message( WARNING "Invalid Release/Debug build type! ${CONFIG}" )
+        message( WARNING "Defaulting to Release_64" )
+        set ( CONFIG "Release" )
+        set ( LENGTH "_64" )
     endif()
 
     #--------------------------------------------------------------------------

--- a/includes.txt
+++ b/includes.txt
@@ -5,7 +5,7 @@
 include_directories( BEFORE
 
   ${CMAKE_BINARY_DIR}
-  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 #------------------------------------------------------------------------------

--- a/includes.txt
+++ b/includes.txt
@@ -4,7 +4,7 @@
 
 include_directories( BEFORE
 
-  ${CMAKE_BINARY_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 


### PR DESCRIPTION
This PR allows the crypto extpkg to be used with a CMake `add_subdirectory()` statement so it can be used as a Git submodule.

Summarised, the following changes are made:

_replace `CMAKE_SOURCE_DIR` with `CMAKE_CURRENT_SOURCE_DIR`_

This allows the use of the extpkg as a Git submodule

_Change the ParseBinaryDir macro to not error out_

Now, when the ParseBinaryDir does not detect the right directory format, it defaults to Release64. This way, existing build infrastructure and scripts keep on working, while the module can be included using an `add_subdirectory()` statement in another `CMakeLists.txt` file.

The latter is not an ideal fix; in an ideal world these settings would be configured with CMake settings so that they can also be configured using eg the curses or QT GUI. Fixing this, however, would result in breaking all existing build scripts, which I'm personally not fond of.